### PR TITLE
Disable playwright on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,4 @@ jobs:
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
       attestation: true
       signature-type: community
+      run-playwright: false


### PR DESCRIPTION
Playwright runs on push already.

https://github.com/grafana/business-charts/issues/3