### PR TITLE
chore: publish requires read access

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ on:
         default: false
         type: boolean
 
-permissions: {}
+permissions: read-all
 
 jobs:
   cd:


### PR DESCRIPTION
adds read permission to publish workflow