### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to **Business Charts** will be documented in this file. This
 - Added pull request coverage and file-changes summary reports.
 - Updated development documentation.
 - Updated development scripts.
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
 
 ## [7.2.0] - 2025-10-22
 


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are
a common supply-chain attack vector.

## What changed

- Added `.npmrc` with `ignore-scripts=true`

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts, so existing installs are
unaffected.

## References

- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)

## Test plan

- [ ] `npm install` completes successfully with `.npmrc` in place