### PR TITLE
docs: remove dead links to shuttered volkov site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to **Business Charts** will be documented in this file. This
 
 ### Project Updates
 
+- Enabled `foldersFromFilesStructure` for dashboard provisioning so the recovered Apache ECharts example dashboards
+  load into a dedicated "echarts" folder instead of the General folder in local development.
+- Updated the Examples documentation to describe the recovered `echarts/` dashboards and how to browse them locally.
+- Removed the defunct `echarts.volkovlabs.io` link from the plugin documentation index.
+- Updated map documentation demo links to point at the recovered **Geo/Map** example dashboard in local development.
 - Removed dependencies on `@volkovlabs/eslint-config` and `@volkovlabs/jest-selectors`. Jest selector helpers (`getJestSelectors`, `createSelector`) are now inlined under `src/test-utils/jest-selectors.ts`. ESLint now relies solely on `@grafana/eslint-config`, with existing rule violations captured in `eslint-suppressions.json`.
 
 ## [7.2.5] - 2026-05-21

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -51,7 +51,7 @@ grafana cli plugins install volkovlabs-echarts-panel
 - Supports real-time data updates using streaming data sources and Grafana Live.
 - Supports light and dark themes adjusted to the Grafana theme.
 - Based on [Apache ECharts 5.5.1](https://github.com/apache/echarts/releases/tag/5.5.1).
-- Provides 100+ ready-to-use examples at [echarts.volkovlabs.io](https://echarts.volkovlabs.io).
+- Includes recovered example dashboards in the [`echarts/`](https://github.com/grafana/business-charts/tree/main/echarts) directory. See [Examples](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/examples/) for how to browse and copy Charts function code.
 - Supports the [Wordcloud extension](https://github.com/ecomfe/echarts-wordcloud).
 
 {{< figure src="/media/docs/grafana/panels-visualizations/business-charts/business-charts.gif" class="border" alt="A few examples of the Business Charts panel." >}}

--- a/docs/sources/examples.md
+++ b/docs/sources/examples.md
@@ -1,6 +1,6 @@
 ---
 title: Examples
-description: Learn how to get started with 100+ ready-to-use chart examples from the Business Charts demo site.
+description: Learn how to get started with recovered Apache ECharts example dashboards and copy Charts function code into your panels.
 weight: 300
 labels:
   products:
@@ -11,20 +11,99 @@ labels:
 
 # Examples
 
-Explore over 100 ready-to-use chart examples on the [Business Charts panel demo site](https://echarts.volkovlabs.io).
+The original Business Charts demo site was hosted externally and was taken down when Volkov Labs discontinued support for this plugin.
 
-{{< figure src="/media/docs/grafana/panels-visualizations/business-charts/examples.png" class="border" alt="Apache ECharts examples adapted for use in Grafana." >}}
+This repository includes recovered example dashboards under the [`echarts/`](https://github.com/grafana/business-charts/tree/main/echarts) directory. Each dashboard contains one or more Business Charts panels with ready-to-use [Charts function](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/charts-function/) code.
+
+## Browse examples locally
+
+The fastest way to explore the examples is to run the local Grafana development environment:
+
+```sh
+npm install
+npm run build
+npm run start:dev
+```
+
+Open Grafana at `http://localhost:3000`, then go to **Dashboards** and open the **echarts** folder. The **Home** dashboard is the default landing page.
+
+The example dashboards are provisioned from the `echarts/` directory in this repository. Each JSON file is a dashboard; open a panel in edit mode to inspect or copy its Charts function.
 
 ## Get started
 
-1. Open [echarts.volkovlabs.io](https://echarts.volkovlabs.io) to view chart examples.
-2. Find a chart similar to the one you want to build.
-3. Open the chart in edit mode (click the three vertical dots at the top right and select Edit).
-   - On the right, find the Code section, then the Function parameter. This is the [Charts function](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/charts-function/).
-   - Review and experiment with the code. The dashboard is read-only, so you cannot save changes.
-   - Copy the Charts function code (everything in the Function parameter).
-
-4. Paste the copied code into the code editor of your Business Charts visualization panel.
-5. Refresh the chart to update its state if it doesn't render instantly.
+1. Find a chart similar to the one you want to build in the **echarts** folder, or browse the [`echarts/`](https://github.com/grafana/business-charts/tree/main/echarts) directory on GitHub.
+1. Open the dashboard and panel in edit mode.
+   - On the right, find the **Code** section, then the **Function** parameter. This is the [Charts function](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/charts-function/).
+   - Review and experiment with the code.
+   - Copy the Charts function code (everything in the **Function** parameter).
+1. Paste the copied code into the code editor of your Business Charts visualization panel.
+1. Refresh the chart to update its state if it does not render instantly.
 
 {{< figure src="/media/docs/grafana/panels-visualizations/business-charts/copy-paste.gif" class="border" alt="To get started: copy from one of the examples and paste to your dashboard." >}}
+
+If you do not run the local development environment, you can still copy Charts function code directly from the `getOption` field in the example dashboard JSON files under `echarts/`.
+
+## Available example dashboards
+
+| Dashboard | Chart types |
+| --------- | ----------- |
+| [Home](https://github.com/grafana/business-charts/blob/main/echarts/home.json) | Overview and links to other examples |
+| [3D Bar / Scatter / Surface](https://github.com/grafana/business-charts/blob/main/echarts/3d.json) | 3D bar, scatter, and surface charts |
+| [Bar](https://github.com/grafana/business-charts/blob/main/echarts/bar.json) | Bar and column charts |
+| [Boxplot](https://github.com/grafana/business-charts/blob/main/echarts/boxplot.json) | Boxplot charts |
+| [Calendar](https://github.com/grafana/business-charts/blob/main/echarts/calendar.json) | Calendar heatmaps |
+| [Candlestick](https://github.com/grafana/business-charts/blob/main/echarts/candlestick.json) | Candlestick and financial charts |
+| [Gauge](https://github.com/grafana/business-charts/blob/main/echarts/gauge.json) | Gauge and progress charts |
+| [Geo/Map](https://github.com/grafana/business-charts/blob/main/echarts/geo-map.json) | GeoJSON and map visualizations |
+| [Graph](https://github.com/grafana/business-charts/blob/main/echarts/graph.json) | Graph and network charts |
+| [Imports](https://github.com/grafana/business-charts/blob/main/echarts/imports.json) | Library import examples |
+| [Line](https://github.com/grafana/business-charts/blob/main/echarts/line.json) | Line and area charts |
+| [Liquid Fill](https://github.com/grafana/business-charts/blob/main/echarts/liquid-fill.json) | Liquid fill charts |
+| [Pie](https://github.com/grafana/business-charts/blob/main/echarts/pie.json) | Pie and donut charts |
+| [Radar](https://github.com/grafana/business-charts/blob/main/echarts/radar.json) | Radar charts |
+| [Sankey](https://github.com/grafana/business-charts/blob/main/echarts/sankey.json) | Sankey diagrams |
+| [Scatter](https://github.com/grafana/business-charts/blob/main/echarts/scatter.json) | Scatter plots |
+| [Sunburst](https://github.com/grafana/business-charts/blob/main/echarts/sunburst.json) | Sunburst charts |
+| [Treemap](https://github.com/grafana/business-charts/blob/main/echarts/treemap.json) | Treemap charts |
+
+## Adapt charts from Apache ECharts
+
+You can also start from any chart on the [Apache ECharts examples site](https://echarts.apache.org/examples/en/index.html). Copy the example `option` object and paste it into a Business Charts panel **Function** parameter with one change: replace `option = { ... }` with `return { ... };`.
+
+For example, the [Basic Radar Chart](https://echarts.apache.org/examples/en/editor.html?c=radar) becomes:
+
+```js
+return {
+  legend: {
+    data: ['Allocated Budget', 'Actual Spending'],
+  },
+  radar: {
+    indicator: [
+      { name: 'Sales', max: 6500 },
+      { name: 'Administration', max: 16000 },
+      { name: 'Information Technology', max: 30000 },
+      { name: 'Customer Support', max: 38000 },
+      { name: 'Development', max: 52000 },
+      { name: 'Marketing', max: 25000 },
+    ],
+  },
+  series: [
+    {
+      name: 'Budget vs spending',
+      type: 'radar',
+      data: [
+        {
+          value: [4200, 3000, 20000, 35000, 50000, 18000],
+          name: 'Allocated Budget',
+        },
+        {
+          value: [5000, 14000, 28000, 26000, 42000, 21000],
+          name: 'Actual Spending',
+        },
+      ],
+    },
+  ],
+};
+```
+
+The recovered **Radar** example dashboard includes this chart and several more advanced radar variants.

--- a/docs/sources/maps/baidu.md
+++ b/docs/sources/maps/baidu.md
@@ -20,7 +20,7 @@ You can get the access key at [https://lbsyun.baidu.com/apiconsole/key#/home](ht
 
 ## Demo
 
-Try the panel with [Baidu Maps in the edit mode](https://echarts.volkovlabs.io/d/X1mkMIFVz/geo-map?orgId=1&editPanel=15).
+After starting the local development environment (see [Examples](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/examples/)), try the [Baidu panel in edit mode](http://localhost:3000/d/X1mkMIFVz/geo-map?orgId=1&editPanel=15) on the **Geo/Map** dashboard in the **echarts** folder.
 
 ## Features
 

--- a/docs/sources/maps/gaode.md
+++ b/docs/sources/maps/gaode.md
@@ -20,7 +20,7 @@ You can get the access key at [https://console.amap.com/dev/key/app](https://con
 
 ## Demo
 
-Try the panel with [Gaode Maps in the edit mode](https://echarts.volkovlabs.io/d/X1mkMIFVz/geo-map?orgId=1&editPanel=17).
+After starting the local development environment (see [Examples](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/examples/)), try the [Gaode Map panel in edit mode](http://localhost:3000/d/X1mkMIFVz/geo-map?orgId=1&editPanel=17) on the **Geo/Map** dashboard in the **echarts** folder.
 
 ## Features
 

--- a/docs/sources/maps/geojson.md
+++ b/docs/sources/maps/geojson.md
@@ -16,7 +16,7 @@ The Business Charts panel supports world and USA GeoJSON maps. You can load addi
 {{< figure src="/media/docs/grafana/panels-visualizations/business-charts/geojson.png" class="border" alt="Website Analytics displays requests per country." >}}
 
 {{< admonition type="note" >}}
-Try the map on the [dashboard in the edit mode](https://echarts.volkovlabs.io/d/X1mkMIFVz/geo-map?orgId=1&editPanel=11).
+After starting the local development environment (see [Examples](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/examples/)), try the [World Population (2022) panel in edit mode](http://localhost:3000/d/X1mkMIFVz/geo-map?orgId=1&editPanel=11) on the **Geo/Map** dashboard in the **echarts** folder.
 {{< /admonition >}}
 
 ## Metrics with values

--- a/docs/sources/maps/google.md
+++ b/docs/sources/maps/google.md
@@ -20,7 +20,7 @@ You can get the access key at [https://console.cloud.google.com/apis/credentials
 
 ## Demo
 
-Try the panel with [Google Maps in the edit mode](https://echarts.volkovlabs.io/d/X1mkMIFVz/geo-map?orgId=1&editPanel=13).
+After starting the local development environment (see [Examples](https://grafana.com/docs/plugins/volkovlabs-echarts-panel/<PLUGINS_VERSION>/examples/)), try the [Google Map panel in edit mode](http://localhost:3000/d/X1mkMIFVz/geo-map?orgId=1&editPanel=13) on the **Geo/Map** dashboard in the **echarts** folder.
 
 ## Features
 

--- a/provisioning/dashboards/default.yaml
+++ b/provisioning/dashboards/default.yaml
@@ -3,5 +3,8 @@ apiVersion: 1
 providers:
   - name: Default # A uniquely identifiable name for the provider
     type: file
+    # Mirror the on-disk folder structure so the recovered echarts/ examples land
+    # in their own "echarts" dashboard folder instead of cluttering "General".
     options:
       path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true


### PR DESCRIPTION
WIP - moving examples to community and/or play instances would be much better then only having examples in local docker, but this is better then linking to dead site